### PR TITLE
'clean' seems to be ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Enable verbose output.
 
 #### options.clean
 Type: `Boolean`
-Default value: `false`
+Default value: `true`
 
 Remove orphaned files from build. **Build only**
 

--- a/tasks/middleman.js
+++ b/tasks/middleman.js
@@ -43,7 +43,7 @@ module.exports = function(grunt) {
       port: 4567,
       glob: false,
       verbose: false,
-      clean: false,
+      clean: true,
       env: {}
     });
 
@@ -73,9 +73,9 @@ module.exports = function(grunt) {
       args.push("--glob=" + options.glob);
     }
 
-    // add the clean option (server only)
-    if(!options.server && options.clean){
-      args.push("--clean");
+    // add the clean option (build only)
+    if(!options.server && !options.clean){
+        args.push("--no-clean");
     }
 
     // add the server options


### PR DESCRIPTION
I'm using the following:

```
middleman: {
            options: {
            },
            server: {
			},
            build: {
                options: {
                    command: "build",
                    clean: false // This does not work
                }
            }
        }
```
with:
`grunt.registerTask('build', ['middleman:build','sass','concat']);`

Unfortunately, it continues to 'clean'. This commit fixes this behaviour and restores the Middleman default.