### PR TITLE
Pass error to `done` telling grunt of finishing the task

### DIFF
--- a/tasks/middleman.js
+++ b/tasks/middleman.js
@@ -113,7 +113,7 @@ module.exports = function(grunt) {
       } else {
         grunt.log.ok("Finished running middleman " + options.command);
       }
-      done();
+      done(error);
     });
 
     process.on("SIGINT", function(e){


### PR DESCRIPTION
Hi,

currently grunt is not able to properly signal failing/succeeding of the task due to missing error argument in `this.async`