### PR TITLE
Ensure that --no-clean is specified

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-middleman",
   "description": "A grunt plugin for running Middleman.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "homepage": "https://github.com/patrickarlt/grunt-middleman",
   "author": {
     "name": "Patrick Arlt",

--- a/tasks/middleman.js
+++ b/tasks/middleman.js
@@ -73,9 +73,13 @@ module.exports = function(grunt) {
       args.push("--glob=" + options.glob);
     }
 
-    // add the clean option (server only)
-    if(!options.server && options.clean){
-      args.push("--clean");
+    // add the clean option (build only)
+    if(!options.server){
+      if (options.clean){
+        args.push("--clean");
+      } else {
+        args.push("--no-clean");
+      }
     }
 
     // add the server options


### PR DESCRIPTION
Middleman defaults to --clean, so --no-clean has to be specified to preserve files in the build directory.